### PR TITLE
updateValue should not send notifyPropertyChanged events by default

### DIFF
--- a/lib/viewmodel/notify_property_changed_mixin.dart
+++ b/lib/viewmodel/notify_property_changed_mixin.dart
@@ -36,14 +36,14 @@ mixin NotifyPropertyChangedMixin
       String propertyName,
       TPropertyType currentValue,
       TPropertyType newValue,
-      SetValue<TPropertyType> setNewValue) {
-    assert(setNewValue != null);
-
+      SetValue<TPropertyType> setNewValue,
+      {bool notifyWhenChanged = false}) {
     if (currentValue == newValue) {
       return false;
     }
     setNewValue(newValue);
-    notifyPropertyChanged(propertyName);
+    if (notifyWhenChanged)
+      notifyPropertyChanged(propertyName);
     return true;
   }
 


### PR DESCRIPTION
- allow updateValue when value is null
- dont send notifyPropertyChanged when notifyWhenChanged is false (to match example code)